### PR TITLE
nix: update quickshell input url

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
 
     quickshell = {
-      url = "git+https://git.outfoxxed.me/outfoxxed/quickshell";
+      url = "git+https://git.outfoxxed.me/quickshell/quickshell";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 


### PR DESCRIPTION
The upstream quickshell repo appears to have been moved to https://git.outfoxxed.me/quickshell/quickshell.
flake.lock will need to be updated as well, but seeing as you have CI workflows for that I didn't do it myself.