### PR TITLE
Make the focusOverlayFlash configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,7 @@ Config lives in:
         "thickness": 10
     },
     "dashboard": {
+        "showOnFocusOverlay": false,
         "mediaUpdateInterval": 500,
         "showOnHover": true
     },

--- a/README.md
+++ b/README.md
@@ -183,6 +183,22 @@ Then simply build and install using `cmake`.
 
     If you get `VERSION is not set and failed to get from git` error, that means I forgot to tag version. You can do `git tag 1.1.1` to work around it :)
 
+### Arch Installation
+If you are on Arch the following commands do a proper installation (mind the prefix):
+```bash
+# Dependencies
+pacman -S --needed cava aubio libpipewire lm_sensors ddcutil brightnessctl grim swappy libqalculate ttf-cascadia-code-nerd qt6-declarative
+yay -S quickshell-git app2unit libcava ttf-material-symbols-variable-git
+# Clone Repo
+cd $XDG_CONFIG_HOME/quickshell
+git clone https://github.com/jutraim/niri-caelestia-shell
+# Build & Install
+cd ~/.config/quickshell/niri-caelestia-shell
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/
+cmake --build build
+sudo cmake --install build
+```
+
 ### 🔃 Updating
 You can update by running `git pull` in `$XDG_CONFIG_HOME/quickshell/niri-caelestia-shell`.
 

--- a/config/DashboardConfig.qml
+++ b/config/DashboardConfig.qml
@@ -6,6 +6,7 @@ JsonObject {
     property int mediaUpdateInterval: 500
     property int dragThreshold: 50
     property Sizes sizes: Sizes {}
+    property bool showOnFocusOverlay: false
 
     component Sizes: JsonObject {
         readonly property int tabIndicatorHeight: 3

--- a/modules/dashboard/Wrapper.qml
+++ b/modules/dashboard/Wrapper.qml
@@ -56,7 +56,7 @@ Item {
         target: Niri
         function onFocusedWindowIdChanged() {
             // Show dashboard for 1 second
-            if ((!root.visibilities.dashboard && !root.expanded) && Niri.focusedWindowId) {
+            if (Config.dashboard.showOnFocusOverlay && (!root.visibilities.dashboard && !root.expanded) && Niri.focusedWindowId) {
                 root.isvisible = true;
                 flashTimer.restart();
             }


### PR DESCRIPTION
When windows change, currently the top dashboard popups for one second.
Somehow this annoyed me, so I made it configurable as the title is already showed on the left bar, which I have persistent). Also most people know where they switch to on scrolling and tiling managers. :)