### PR TITLE
Fix Cava 0.10.7 Build Error and Add 2-in-1 Update and Patch Script

### DIFF
--- a/plugin/src/Caelestia/CMakeLists.txt
+++ b/plugin/src/Caelestia/CMakeLists.txt
@@ -17,7 +17,6 @@ qt_add_qml_module(caelestia
         serviceref.hpp serviceref.cpp
         audiocollector.hpp audiocollector.cpp
         audioprovider.hpp audioprovider.cpp
-        cavaprovider.hpp cavaprovider.cpp
 )
 
 qt_query_qml_module(caelestia

--- a/services/BeatDetector.qml
+++ b/services/BeatDetector.qml
@@ -1,29 +1,5 @@
-pragma Singleton
+import QtQuick
 
-import qs.utils
-import Quickshell
-
-// import Quickshell.Io
-
-Singleton {
-    id: root
-
-    property real bpm: 150
-
-    // This is a simple beat detector service that runs an external process to analyze audio input and extract the BPM (beats per minute).
-    // It is disabled by default, as it requires an external binary (beat_detector) to be present in the specified path.
-    // To enable it, uncomment the Process block below and ensure that the beat_detector binary is available in the CAELESTIA_LIB_DIR/beat_detector directory.
-    // The beat_detector binary should be compiled from the source available at the main repo.
-
-    // Process {
-    //     running: true
-    //     command: [`${Paths.libdir}/beat_detector`, "--no-log", "--no-stats", "--no-visual"]
-    //     stdout: SplitParser {
-    //         onRead: data => {
-    //             const match = data.match(/BPM: ([0-9]+\.[0-9])/);
-    //             if (match)
-    //                 root.bpm = parseFloat(match[1]);
-    //         }
-    //     }
-    // }
+QtObject {
+    // BeatDetector Disabled by Sarok
 }

--- a/services/Cava.qml
+++ b/services/Cava.qml
@@ -1,18 +1,5 @@
-pragma Singleton
+import QtQuick
 
-import qs.config
-import Caelestia
-import Quickshell
-
-Singleton {
-    id: root
-
-    readonly property alias provider: provider
-    readonly property alias values: provider.values
-
-    CavaProvider {
-        id: provider
-
-        bars: Config.services.visualiserBars
-    }
+QtObject {
+    // Cava Disabled by Sarok
 }

--- a/update_shell.sh
+++ b/update_shell.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# Configuration
+SHELL_DIR="$HOME/.config/quickshell/niri-caelestia-shell"
+REPO_URL="https://github.com/jutraim/niri-caelestia-shell"
+LOG_FILE="$HOME/caelestia_update.log"
+
+# Function to show progress
+show_progress() {
+    local message=$1
+    local percent=$2
+    echo -ne "  [Updating] $percent% : $message\r"
+}
+
+# Custom Logo
+clear
+echo -e "\e[1;34m"
+echo "             ____  ____  ___  ____________"
+echo "      __  __/ __ \/ __ \/   |/_  __/ ____/"
+echo "     / / / / /_/ / / / / /| | / / / __/   "
+echo "    / /_/ / ____/ /_/ / ___ |/ / / /___  "
+echo "    \__,_/_/   /_____/_/  |_/_/ /_____/  "
+echo -e "\e[0m"
+
+echo "Initializing Clean Update Engine..."
+echo "Logs are being saved to: $LOG_FILE"
+echo "----------------------------------------------------------"
+
+# 1. Directory & Git Setup
+show_progress "Configuring Repository" 10
+if [ ! -d "$SHELL_DIR" ]; then
+    mkdir -p "$SHELL_DIR"
+fi
+cd "$SHELL_DIR" || exit
+if [ ! -d ".git" ]; then
+    git init &>> "$LOG_FILE"
+    git remote add origin "$REPO_URL" &>> "$LOG_FILE"
+else
+    git remote set-url origin "$REPO_URL" &>> "$LOG_FILE"
+fi
+
+# 2. Pulling Updates
+show_progress "Fetching latest changes" 25
+git fetch origin &>> "$LOG_FILE"
+git checkout -f main &>> "$LOG_FILE"
+git pull origin main &>> "$LOG_FILE"
+git tag 1.1.1 2>/dev/null
+
+# 3. Cleaning & Patching
+show_progress "Applying Cava-Removal patches" 45
+rm -rf build &>> "$LOG_FILE"
+sed -i '/cavaprovider/d' plugin/src/Caelestia/CMakeLists.txt
+sed -i '/PkgConfig::cava/d' plugin/src/Caelestia/CMakeLists.txt
+
+# QML Patching
+if [ -f "services/Cava.qml" ]; then
+    echo -e "import QtQuick\n\nQtObject {\n    // Cava Disabled by Sarok\n}" > services/Cava.qml
+fi
+if [ -f "services/BeatDetector.qml" ]; then
+    echo -e "import QtQuick\n\nQtObject {\n    // BeatDetector Disabled by Sarok\n}" > services/BeatDetector.qml
+fi
+
+# 4. Building (The heavy part)
+show_progress "Compiling C++ Plugin (Please wait)" 70
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release &>> "$LOG_FILE"
+if [ $? -eq 0 ]; then
+    cmake --build build &>> "$LOG_FILE"
+    
+    # 5. Installing
+    show_progress "Installing to system" 90
+    sudo cmake --install build &>> "$LOG_FILE"
+    
+    echo -ne "\n\n"
+    echo "SUCCESS: Update completed successfully."
+    echo "----------------------------------------------------------"
+    
+    # Restart Prompt
+    read -p "Restart shell now? (y/n) " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        killall quickshell 2>/dev/null
+        qs -c niri-caelestia-shell &> /dev/null &
+        echo "Shell restarted in background."
+    fi
+else
+    echo -e "\n\nERROR: Build failed. Check $LOG_FILE for details."
+fi


### PR DESCRIPTION
I encountered a build failure on Arch Linux caused by the new Cava v0.10.7 API changes. To solve this, I created a 2-in-1 solution that handles both the update process and the fix.

The Solution:
I implemented a temporary workaround by neutralizing the Cava provider to allow successful compilation. This is a survival fix to keep the shell functional for everyone on rolling-release distros while we wait for a permanent fix for the new Cava API.

What is included in this PR:

The Fix: Neutralized cavaprovider and placeholder QML services to bypass the build errors.

update_shell.sh: A 2-in-1 automated script that pulls the latest changes and automatically applies the Cava patch. It includes a progress bar and a custom UI for a better user experience.

I am sharing this to help other users who are currently unable to build the shell. Let me know what you think.